### PR TITLE
Fix missing comma in creating results dict

### DIFF
--- a/01_cifar10_tinyvgg.ipynb
+++ b/01_cifar10_tinyvgg.ipynb
@@ -726,7 +726,7 @@
     "    \"num_test_samples\": len(test_data),\n",
     "    \"total_train_time\": round(total_train_time, 3),\n",
     "    \"time_per_epoch\": round(total_train_time/NUM_EPOCHS, 3),\n",
-    "    \"model\": model.__class__.__name__\n",
+    "    \"model\": model.__class__.__name__,\n",
     "    \"test_accuracy\": model_results[\"test_acc\"][-1]\n",
     "    }\n",
     "    \n",


### PR DESCRIPTION
Fix for missing comma as reported in Issue #4 

Tested locally (macos+arm)